### PR TITLE
Add `OPERATOR_PASSWORD` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This is a ready to go HA Postgres app that runs on Fly.
 Init gets you going with a Fly application and generates a config file.
 
 ### Set secrets
-This app requires `SU_PASSWORD` and `REPL_PASSWORD` environment variables.
+This app requires `SU_PASSWORD`, `REPL_PASSWORD`, and `OPERATOR_PASSWORD` environment variables.
 
-`SU_PASSWORD` is the PostgreSQL super user password, the username is `flypgadmin`. You can use this to administer the database once it's running. You should create less privileged users for your applications to use.
+`SU_PASSWORD` is the PostgreSQL super user password, the username is `flypgadmin`. `OPERATOR_PASSWORD` is the password for the `postgres` user. You can use this to administer the database once it's running. You should create less privileged users for your applications to use.
 
 `REPL_PASSWORD` is used to replicate between instances.
 
-> `flyctl secrets set SU_PASSWORD=<PASSWORD> REPL_PASSWORD=<PASSWORD>`
+> `flyctl secrets set SU_PASSWORD=<PASSWORD> REPL_PASSWORD=<PASSWORD> OPERATOR_PASSWOD=<PASSWORD>`
 
 ## Deploy one instance
 


### PR DESCRIPTION
Hello, I found myself deploying this app manually as I need PostGIS support. I noticed that the README is telling me to set the `SU_PASSWORD` and the `REPL_PASSWORD`, but not the `OPERATOR_PASSWORD` so I end up with the `postgres` user having the default password of `operatorpassword`.

I wasn't sure what the difference in intention between the `flypgadmin` and the `postgres` users are so I left this vague in the README. Please do clarify the distinction if you think it's important.

Also, the README indicates that these environment variables are required, but this isn't technically true: the app deploys fine with the defaults. Perhaps it shouldn't?