### PR TITLE
Adding Etcdv3 support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/flyadmin ./cmd/flyadmin
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/flycheck ./cmd/flycheck
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
 
-FROM flyio/stolon:401b5cc as stolon
+FROM flyio/stolon:cab0fc5  as stolon
 
 FROM wrouesnel/postgres_exporter:latest AS postgres_exporter
 

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -102,8 +102,8 @@ func main() {
 		"STKEEPER_PG_PORT":           strconv.Itoa(node.PGPort),
 		"STKEEPER_LOG_LEVEL":         "info",
 		"STKEEPER_CLUSTER_NAME":      node.AppName,
-		"STKEEPER_STORE_BACKEND":     "consul",
-		"STKEEPER_STORE_URL":         node.ConsulURL.String(),
+		"STKEEPER_STORE_BACKEND":     node.BackendStore,
+		"STKEEPER_STORE_URL":         node.BackendStoreURL.String(),
 		"STKEEPER_STORE_NODE":        node.StoreNode,
 	}
 
@@ -119,8 +119,8 @@ func main() {
 		"STSENTINEL_INITIAL_CLUSTER_SPEC": "/fly/cluster-spec.json",
 		"STSENTINEL_LOG_LEVEL":            "info",
 		"STSENTINEL_CLUSTER_NAME":         node.AppName,
-		"STSENTINEL_STORE_BACKEND":        "consul",
-		"STSENTINEL_STORE_URL":            node.ConsulURL.String(),
+		"STSENTINEL_STORE_BACKEND":        node.BackendStore,
+		"STSENTINEL_STORE_URL":            node.BackendStoreURL.String(),
 		"STSENTINEL_STORE_NODE":           node.StoreNode,
 	}
 
@@ -131,8 +131,8 @@ func main() {
 		"STPROXY_PORT":           strconv.Itoa(node.PGProxyPort),
 		"STPROXY_LOG_LEVEL":      "info",
 		"STPROXY_CLUSTER_NAME":   node.AppName,
-		"STPROXY_STORE_BACKEND":  "consul",
-		"STPROXY_STORE_URL":      node.ConsulURL.String(),
+		"STPROXY_STORE_BACKEND":  node.BackendStore,
+		"STPROXY_STORE_URL":      node.BackendStoreURL.String(),
 		"STPROXY_STORE_NODE":     node.StoreNode,
 	}
 
@@ -169,8 +169,8 @@ func main() {
 func writeStolonctlEnvFile(n *flypg.Node, filename string) {
 	var b bytes.Buffer
 	b.WriteString("STOLONCTL_CLUSTER_NAME=" + n.AppName + "\n")
-	b.WriteString("STOLONCTL_STORE_BACKEND=consul\n")
-	b.WriteString("STOLONCTL_STORE_URL=" + n.ConsulURL.String() + "\n")
+	b.WriteString("STOLONCTL_STORE_BACKEND=" + n.BackendStore + "\n")
+	b.WriteString("STOLONCTL_STORE_URL=" + n.BackendStoreURL.String() + "\n")
 	b.WriteString("STOLONCTL_STORE_NODE=" + n.StoreNode + "\n")
 
 	os.WriteFile(filename, b.Bytes(), 0644)

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,6 @@
 # fly.toml file generated for postgres-ha-example on 2020-12-22T12:44:02-06:00
 
-app = "md-pg"
+app = "postgres-ha-example"
 
 # stop accepting new connections while existing sessions complete
 kill_signal = "SIGTERM"
@@ -8,6 +8,7 @@ kill_signal = "SIGTERM"
 kill_timeout = 300
 
 [env]
+BACKEND_STORE = "consul"
 PRIMARY_REGION = "dfw"
 
 [checks.role]

--- a/pkg/flypg/stolon.go
+++ b/pkg/flypg/stolon.go
@@ -35,8 +35,8 @@ func (n *Node) GetStolonClusterData() (s stolon.ClusterData, err error) {
 	cmd := exec.Command("stolonctl", "clusterdata", "read")
 	cmd.Env = append(os.Environ(),
 		"STOLONCTL_CLUSTER_NAME="+n.AppName,
-		"STOLONCTL_STORE_BACKEND="+"consul",
-		"STOLONCTL_STORE_URL="+n.ConsulURL.String(),
+		"STOLONCTL_STORE_BACKEND="+n.BackendStore,
+		"STOLONCTL_STORE_URL="+n.BackendStoreURL.String(),
 		"STOLONCTL_STORE_NODE="+n.StoreNode,
 	)
 


### PR DESCRIPTION
Allow users to choose between Etcd and Consul as their backend store. 

The target backend store is specified via the `BACKEND_STORE` environment variable. 
The two accepted backend stores are: `etcdv3` and `consul`. 

**Example**
```toml
[env]
  BACKEND_STORE="etcdv3"
  ETCD_URL="http://root:xxxxxx@myendpoint.net:2379"  # Should be a secret.

```


_Note:  If `BACKEND_STORE` is unspecified it will default to `consul`._ 
