### PR TITLE
Bind proxy to 0.0.0.0

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"os/user"
@@ -127,7 +128,7 @@ func main() {
 	svisor.AddProcess("sentinel", "stolon-sentinel", supervisor.WithEnv(sentinelEnv))
 
 	proxyEnv := map[string]string{
-		"STPROXY_LISTEN_ADDRESS": node.PrivateIP.String(),
+		"STPROXY_LISTEN_ADDRESS": net.ParseIP("0.0.0.0").String(),
 		"STPROXY_PORT":           strconv.Itoa(node.PGProxyPort),
 		"STPROXY_LOG_LEVEL":      "info",
 		"STPROXY_CLUSTER_NAME":   node.AppName,


### PR DESCRIPTION
Allows clients to connect using ipv4 address.  E.G. xxxx.fly.dev address with external service port. 