### PR TITLE
Standardize usernames and remove default passwords

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -82,7 +82,6 @@ func main() {
 						fmt.Println("error configuring operator:", err)
 						continue
 					}
-					fmt.Println("operator ready!")
 				}
 
 				return
@@ -228,6 +227,8 @@ func initOperator(ctx context.Context, pg *pgx.Conn, creds flypg.Credentials) er
 			return err
 		}
 	}
+
+	fmt.Println("operator ready!")
 
 	return nil
 }

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -182,19 +182,3 @@ func (n *Node) NewProxyConnection(ctx context.Context) (*pgx.Conn, error) {
 	host := net.JoinHostPort(n.PrivateIP.String(), strconv.Itoa(n.PGProxyPort))
 	return openConnection(ctx, []string{host}, "any", n.SUCredentials)
 }
-
-func envOrDefault(name, defaultVal string) string {
-	val, ok := os.LookupEnv(name)
-	if ok {
-		return val
-	}
-	return defaultVal
-}
-
-func requireEnv(str string) (string, error) {
-	var ev string
-	if ev = os.Getenv(str); ev == "" {
-		return "", fmt.Errorf("%s is required", str)
-	}
-	return ev, nil
-}


### PR DESCRIPTION
**Notable changes**

* Removes customization of the `SU_USER` and `REPL_USER`.  Superuser and Replication user will be assigned to `flypgadmin` and `repluser` respectively. 
* Removes default passwords and enforces the the required `SU_PASSWORD` and `REPL_PASSWORD` environment variables.
* The operator user is now truly optional and will be conditionally added based on the presence of the `OPERATOR_PASSWORD` environment variable.  
* The operator username will be set to `postgres` by convention.