### PR TITLE
Restarts

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -124,7 +124,7 @@ func main() {
 		keeperEnv["STKEEPER_CAN_BE_SYNCHRONOUS_REPLICA"] = "false"
 	}
 
-	svisor.AddProcess("keeper", stolonCmd("stolon-keeper"), supervisor.WithEnv(keeperEnv))
+	svisor.AddProcess("keeper", stolonCmd("stolon-keeper"), supervisor.WithEnv(keeperEnv), supervisor.WithRestart(10, 10*time.Second))
 
 	sentinelEnv := map[string]string{
 		"STSENTINEL_DATA_DIR":             node.DataDir,
@@ -136,7 +136,7 @@ func main() {
 		"STSENTINEL_STORE_NODE":           node.StoreNode,
 	}
 
-	svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithEnv(sentinelEnv))
+	svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithEnv(sentinelEnv), supervisor.WithRestart(0, 3*time.Second))
 
 	proxyEnv := map[string]string{
 		"STPROXY_LISTEN_ADDRESS": net.ParseIP("0.0.0.0").String(),
@@ -148,7 +148,7 @@ func main() {
 		"STPROXY_STORE_NODE":     node.StoreNode,
 	}
 
-	svisor.AddProcess("proxy", stolonCmd("stolon-proxy"), supervisor.WithEnv(proxyEnv))
+	svisor.AddProcess("proxy", stolonCmd("stolon-proxy"), supervisor.WithEnv(proxyEnv), supervisor.WithRestart(0, 3*time.Second))
 
 	exporterEnv := map[string]string{
 		"DATA_SOURCE_URI":                      fmt.Sprintf("[%s]:%d/postgres?sslmode=disable", node.PrivateIP, node.PGPort),
@@ -160,7 +160,7 @@ func main() {
 		"PG_EXPORTER_EXTEND_QUERY_PATH":        "/fly/queries.yaml",
 	}
 
-	svisor.AddProcess("exporter", "postgres_exporter", supervisor.WithEnv(exporterEnv))
+	svisor.AddProcess("exporter", "postgres_exporter", supervisor.WithEnv(exporterEnv), supervisor.WithRestart(0, 1*time.Second))
 
 	if err := flypg.InitConfig("/fly/cluster-spec.json"); err != nil {
 		panic(err)

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -167,17 +166,14 @@ func main() {
 		panic(err)
 	}
 
-	sigch := make(chan os.Signal)
-	signal.Notify(sigch, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		<-sigch
-		fmt.Println("Got interrupt, stopping")
-		svisor.Stop()
-	}()
+	svisor.StopOnSignal(syscall.SIGINT, syscall.SIGTERM)
 
 	svisor.StartHttpListener()
-	svisor.Run()
+	err = svisor.Run()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 func writeStolonctlEnvFile(n *flypg.Node, filename string) {

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	stolonCmd := func(cmd string) string {
-		return fmt.Sprintf("/bin/sh -c gosu stolon %s", cmd)
+		return "gosu stolon " + cmd
 	}
 
 	go func() {

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -57,6 +57,10 @@ func main() {
 		panic(err)
 	}
 
+	stolonCmd := func(cmd string) string {
+		return fmt.Sprintf("/bin/sh -c gosu stolon %s", cmd)
+	}
+
 	go func() {
 		t := time.NewTicker(1 * time.Second)
 		defer t.Stop()
@@ -121,7 +125,7 @@ func main() {
 		keeperEnv["STKEEPER_CAN_BE_SYNCHRONOUS_REPLICA"] = "false"
 	}
 
-	svisor.AddProcess("keeper", "stolon-keeper", supervisor.WithEnv(keeperEnv))
+	svisor.AddProcess("keeper", stolonCmd("stolon-keeper"), supervisor.WithEnv(keeperEnv))
 
 	sentinelEnv := map[string]string{
 		"STSENTINEL_DATA_DIR":             node.DataDir,
@@ -133,7 +137,7 @@ func main() {
 		"STSENTINEL_STORE_NODE":           node.StoreNode,
 	}
 
-	svisor.AddProcess("sentinel", "stolon-sentinel", supervisor.WithEnv(sentinelEnv))
+	svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithEnv(sentinelEnv))
 
 	proxyEnv := map[string]string{
 		"STPROXY_LISTEN_ADDRESS": net.ParseIP("0.0.0.0").String(),
@@ -145,7 +149,7 @@ func main() {
 		"STPROXY_STORE_NODE":     node.StoreNode,
 	}
 
-	svisor.AddProcess("proxy", "stolon-proxy", supervisor.WithEnv(proxyEnv))
+	svisor.AddProcess("proxy", stolonCmd("stolon-proxy"), supervisor.WithEnv(proxyEnv))
 
 	exporterEnv := map[string]string{
 		"DATA_SOURCE_URI":                      fmt.Sprintf("[%s]:%d/postgres?sslmode=disable", node.PrivateIP, node.PGPort),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fly-examples/postgres-ha
 go 1.16
 
 require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/jackc/pgtype v1.6.2 // indirect
 	github.com/jackc/pgx/v4 v4.10.1
 	github.com/kr/pretty v0.2.0 // indirect
@@ -10,5 +11,6 @@ require (
 	github.com/pkg/term v1.1.0
 	github.com/shirou/gopsutil/v3 v3.21.3
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -143,6 +145,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/supervisor/ensure_kill.go
+++ b/pkg/supervisor/ensure_kill.go
@@ -2,6 +2,8 @@
 
 package supervisor
 
-func ensureKill(p *process) {
-	// p.SysProcAttr.Pdeathsig in supported on on Linux, we can't do anything here
+import "os/exec"
+
+func ensureKill(cmd *exec.Cmd) {
+	// cmd.SysProcAttr.Pdeathsig in supported on on Linux, we can't do anything here
 }

--- a/pkg/supervisor/ensure_kill_linux.go
+++ b/pkg/supervisor/ensure_kill_linux.go
@@ -4,6 +4,6 @@ package supervisor
 
 import "syscall"
 
-func ensureKill(p *process) {
-	p.SysProcAttr.Pdeathsig = syscall.SIGKILL
+func ensureKill(cmd *exec.Cmd) {
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }

--- a/pkg/supervisor/ensure_kill_linux.go
+++ b/pkg/supervisor/ensure_kill_linux.go
@@ -2,7 +2,10 @@
 
 package supervisor
 
-import "syscall"
+import (
+	"os/exec"
+	"syscall"
+)
 
 func ensureKill(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL

--- a/pkg/supervisor/output.go
+++ b/pkg/supervisor/output.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 
 	"github.com/pkg/term/termios"
 )
@@ -29,10 +28,11 @@ func (m *multiOutput) openPipe(proc *process) (pipe *ptyPipe) {
 	pipe.pty, pipe.tty, err = termios.Pty()
 	fatalOnErr(err)
 
-	proc.Stdout = pipe.tty
-	proc.Stderr = pipe.tty
-	proc.Stdin = pipe.tty
-	proc.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
+	proc.cmd.Stdout = pipe.tty
+	proc.cmd.Stderr = pipe.tty
+	proc.cmd.Stdin = pipe.tty
+	proc.cmd.SysProcAttr.Setctty = true
+	proc.cmd.SysProcAttr.Setsid = true
 
 	return
 }

--- a/pkg/supervisor/process.go
+++ b/pkg/supervisor/process.go
@@ -8,8 +8,9 @@ import (
 	"time"
 )
 
+type cmdFactory func() *exec.Cmd
+
 type process struct {
-	*exec.Cmd
 	name         string
 	color        int
 	output       *multiOutput
@@ -17,7 +18,11 @@ type process struct {
 	restart      bool
 	restartDelay time.Duration
 	maxRestarts  int
-	restartCount int
+
+	f   cmdFactory
+	dir string
+	env []string
+	cmd *exec.Cmd
 }
 
 type Opt func(*process)
@@ -25,7 +30,7 @@ type Opt func(*process)
 func WithEnv(env map[string]string) Opt {
 	return func(proc *process) {
 		for k, v := range env {
-			proc.Env = append(proc.Env, fmt.Sprintf("%s=%s", k, v))
+			proc.env = append(proc.env, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
 }
@@ -38,7 +43,7 @@ func WithStopSignal(sig os.Signal) Opt {
 
 func WithRootDir(dir string) Opt {
 	return func(proc *process) {
-		proc.Dir = dir
+		proc.dir = dir
 	}
 }
 
@@ -59,7 +64,7 @@ func (p *process) writeErr(err error) {
 }
 
 func (p *process) signal(sig os.Signal) {
-	group, err := os.FindProcess(-p.Process.Pid)
+	group, err := os.FindProcess(-p.cmd.Process.Pid)
 	if err != nil {
 		p.writeErr(err)
 		return
@@ -71,10 +76,15 @@ func (p *process) signal(sig os.Signal) {
 }
 
 func (p *process) Running() bool {
-	return p.Process != nil && p.ProcessState == nil
+	return p.cmd != nil && p.cmd.Process != nil && p.cmd.ProcessState == nil
 }
 
 func (p *process) Run() {
+	p.cmd = p.f()
+	defer func() {
+		p.cmd = nil
+	}()
+
 	p.output.PipeOutput(p)
 	defer p.output.ClosePipe(p)
 
@@ -82,10 +92,11 @@ func (p *process) Run() {
 
 	p.writeLine([]byte("\033[1mRunning...\033[0m"))
 
-	if err := p.Cmd.Run(); err != nil {
+	if err := p.cmd.Run(); err != nil {
 		p.writeErr(err)
 	} else {
-		p.writeLine([]byte("\033[1mProcess exited\033[0m"))
+		status := p.cmd.ProcessState.ExitCode()
+		p.writeLine([]byte(fmt.Sprintf("\033[1mProcess exited %d\033[0m", status)))
 	}
 }
 

--- a/pkg/supervisor/process.go
+++ b/pkg/supervisor/process.go
@@ -78,7 +78,7 @@ func (p *process) Run() {
 	p.output.PipeOutput(p)
 	defer p.output.ClosePipe(p)
 
-	ensureKill(p)
+	ensureKill(p.cmd)
 
 	p.writeLine([]byte("\033[1mRunning...\033[0m"))
 

--- a/pkg/supervisor/process.go
+++ b/pkg/supervisor/process.go
@@ -19,10 +19,11 @@ type process struct {
 	restartDelay time.Duration
 	maxRestarts  int
 
-	f   cmdFactory
-	dir string
-	env []string
-	cmd *exec.Cmd
+	f       cmdFactory
+	running bool
+	dir     string
+	env     []string
+	cmd     *exec.Cmd
 }
 
 type Opt func(*process)
@@ -47,10 +48,12 @@ func WithRootDir(dir string) Opt {
 	}
 }
 
-func WithRestart(maxRestarts int, delay time.Duration) Opt {
+// WithRestart restarts the process if it exists. If limit
+// is 0 it will restart forever.
+func WithRestart(limit int, delay time.Duration) Opt {
 	return func(proc *process) {
 		proc.restart = true
-		proc.maxRestarts = maxRestarts
+		proc.maxRestarts = limit
 		proc.restartDelay = delay
 	}
 }

--- a/pkg/supervisor/process.go
+++ b/pkg/supervisor/process.go
@@ -5,14 +5,19 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 type process struct {
 	*exec.Cmd
-	name       string
-	color      int
-	output     *multiOutput
-	stopSignal os.Signal
+	name         string
+	color        int
+	output       *multiOutput
+	stopSignal   os.Signal
+	restart      bool
+	restartDelay time.Duration
+	maxRestarts  int
+	restartCount int
 }
 
 type Opt func(*process)
@@ -34,6 +39,14 @@ func WithStopSignal(sig os.Signal) Opt {
 func WithRootDir(dir string) Opt {
 	return func(proc *process) {
 		proc.Dir = dir
+	}
+}
+
+func WithRestart(maxRestarts int, delay time.Duration) Opt {
+	return func(proc *process) {
+		proc.restart = true
+		proc.maxRestarts = maxRestarts
+		proc.restartDelay = delay
 	}
 }
 

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fly-examples/postgres-ha/pkg/flycheck"
+	"github.com/google/shlex"
 )
 
 type Supervisor struct {
@@ -32,7 +33,7 @@ func New(name string, timeout time.Duration) *Supervisor {
 
 var colors = []int{2, 3, 4, 5, 6, 42, 130, 103, 129, 108}
 
-func (h *Supervisor) AddProcess(name string, command string, args []string, opts ...Opt) {
+func (h *Supervisor) AddProcess(name string, command string, opts ...Opt) {
 	proc := &process{
 		name:       name,
 		color:      colors[len(h.procs)%len(colors)],
@@ -41,9 +42,11 @@ func (h *Supervisor) AddProcess(name string, command string, args []string, opts
 		env:        os.Environ(),
 	}
 
+	parsedCmd, err := shlex.Split(command)
+	fatalOnErr(err)
+
 	proc.f = func() *exec.Cmd {
-		cmd := exec.Command(command, args...)
-		// cmd := exec.Command("/bin/sh", "-c", "gosu stolon "+command)
+		cmd := exec.Command(parsedCmd[0], parsedCmd[1:]...)
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 		// cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 


### PR DESCRIPTION
This adds support for restarting processes to the supervisor along with a few other bugs that might have caused improper shutdowns. 


Configuring restarts
```
// restart up to 10 times with a 10 second delay
svisor.AddProcess("keeper", stolonCmd("stolon-keeper"), supervisor.WithRestart(10, 10*time.Second))

// restart forever with a 3 second delay
svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithRestart(0, 3*time.Second))
```

`supervisor.Run` returns an error now which will be nil if all processes exited cleanly or a `processError` if a process exhausted it's restart limit. The supervisor will exit with a code 1 if a process crashed too many times.
```
	err = svisor.Run()
	if err != nil {
		fmt.Println(err)
		os.Exit(1)
	}
```

I also noticed the `AddProcess` function was hardcoding a `/bin/sh -c gosu stolon %s` prefix on commands. I removed that so I could test locally and moved the prefix formatting to the local `stolonCmd` function in `start/main.go`

I tested this with docker compose locally and it appears to be working. In order to test failures I made a new binary and scripts in this branch: https://github.com/fly-apps/postgres-ha/blob/test-restarts/cmd/restarter/main.go.