### PR TITLE
Don't create replUser on initial bootstrap

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -104,8 +104,7 @@ func main() {
 						continue
 					}
 
-					// Stolon will handle replUser creation during initial bootstrap.
-					//
+					// Stolon handles replUser creation during initial bootstrap.
 					if cfg.InitMode == flypg.InitModeExisting {
 						if err = initReplicationUser(context.TODO(), pg, node.ReplCredentials); err != nil {
 							fmt.Println("error configuring replication user:", err)

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -104,7 +104,8 @@ func main() {
 						continue
 					}
 
-					// If initMode is "new", Stolon will handle replUser creation.
+					// Stolon will handle replUser creation during initial bootstrap.
+					//
 					if cfg.InitMode == flypg.InitModeExisting {
 						if err = initReplicationUser(context.TODO(), pg, node.ReplCredentials); err != nil {
 							fmt.Println("error configuring replication user:", err)
@@ -142,8 +143,6 @@ func main() {
 		keeperEnv["STKEEPER_CAN_BE_SYNCHRONOUS_REPLICA"] = "false"
 	}
 
-	fmt.Printf("Keeper config: %+v\n", keeperEnv)
-
 	svisor.AddProcess("keeper", stolonCmd("stolon-keeper"), supervisor.WithEnv(keeperEnv), supervisor.WithRestart(5, 5*time.Second))
 
 	sentinelEnv := map[string]string{
@@ -155,8 +154,6 @@ func main() {
 		"STSENTINEL_STORE_URL":            node.BackendStoreURL.String(),
 		"STSENTINEL_STORE_NODE":           node.StoreNode,
 	}
-
-	fmt.Printf("Sentinel config: %+v\n", sentinelEnv)
 
 	svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithEnv(sentinelEnv), supervisor.WithRestart(0, 3*time.Second))
 


### PR DESCRIPTION
This PR works to address a fun race condition. 

Stolon creates the `replUser` as part of the bootstrap process, and we work to create the `replUser` if it doesn't exist at boot time.  If our logic runs before Stolon's, Stolon will fail because it doesn't properly check to see if the `replUser` exists before attempting to create it.  The failure causes Stolon to re-bootstrap the cluster which ends up clearing out any users that are not the SU_USER or REPL_USER.  So really just the OPERATOR_USER, which is `postgres`.

https://github.com/sorintlab/stolon/blob/057389f7e484ee1d5c1e1a7020256020e7413c87/internal/postgresql/postgresql.go#L580-L582



