### PR TITLE
stolonctl-run binary

### DIFF
--- a/bin/stolonctl-run
+++ b/bin/stolonctl-run
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export $(cat /data/.env | xargs)
+
+encoded_cmd=$1
+cmd=$(echo -n $encoded_cmd | base64 -d)
+
+stolonctl $cmd


### PR DESCRIPTION
Basic `stolonctl-run` binary that allows flyctl to interact with stolonctl.  