### PR TITLE
Include wal-g as part of the Dockerfile build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG PG_VERSION=14.2
 ARG VERSION=custom
+ARG WALG_VERSION=1.1
 
 FROM golang:1.16 as flyutil
 ARG VERSION
@@ -34,7 +35,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates curl bash dnsutils vim-tiny procps jq haproxy \
     postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
     postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \    
-    && apt autoremove -y
+    && apt autoremove -y \
+    && echo 'Installing wal-g' \
+    && curl -L https://github.com/wal-g/wal-g/releases/download/v$WALG_VERSION/wal-g-pg-ubuntu-18.04-amd64 > /usr/local/bin/wal-g \
+    && chmod +x /usr/local/bin/wal-g
 
 COPY --from=stolon /go/src/app/bin/* /usr/local/bin/
 COPY --from=postgres_exporter /postgres_exporter /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG PG_VERSION=14.2
 ARG VERSION=custom
-ARG WALG_VERSION=1.1
 
 FROM golang:1.16 as flyutil
 ARG VERSION
@@ -26,6 +25,7 @@ FROM wrouesnel/postgres_exporter:latest AS postgres_exporter
 FROM postgres:${PG_VERSION}
 ARG VERSION 
 ARG POSTGIS_MAJOR=3
+ARG WALG_VERSION=1.1
 
 LABEL fly.app_role=postgres_cluster
 LABEL fly.version=${VERSION}
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \    
     && apt autoremove -y \
     && echo 'Installing wal-g' \
-    && curl -L https://github.com/wal-g/wal-g/releases/download/v$WALG_VERSION/wal-g-pg-ubuntu-18.04-amd64 > /usr/local/bin/wal-g \
+    && curl -L https://github.com/wal-g/wal-g/releases/download/v${WALG_VERSION}/wal-g-pg-ubuntu-18.04-amd64 > /usr/local/bin/wal-g \
     && chmod +x /usr/local/bin/wal-g
 
 COPY --from=stolon /go/src/app/bin/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM wrouesnel/postgres_exporter:latest AS postgres_exporter
 FROM postgres:${PG_VERSION}
 ARG VERSION 
 ARG POSTGIS_MAJOR=3
-ARG WALG_VERSION=1.1
+ARG WALG_VERSION=2.0.0
 
 LABEL fly.app_role=postgres_cluster
 LABEL fly.version=${VERSION}

--- a/pkg/flypg/config.go
+++ b/pkg/flypg/config.go
@@ -105,6 +105,9 @@ func InitConfig(filename string) (*Config, error) {
 			"max_parallel_workers":            "8",
 			"max_parallel_workers_per_gather": "2",
 			"wal_compression":                 "on",
+			"archive_mode":                    "on",
+			"archive_command":                 "if [ $ENABLE_WALG ]; then /usr/local/bin/wal-g wal-push \"%p\"; fi",
+			"archive_timeout":                 "60",
 		},
 	}
 


### PR DESCRIPTION
By including wal-g, people are able to set up their own streaming backups with more granularity and versatility than the daily volume snapshots which Fly currently provides.

Wal-g can almost completely be managed from Fly's env variables (+ secrets).

There is one thing which I have not figured out yet (help is greatly appreciated!):
Wal-g's streaming replication is enabled as part of Postgres by adding the following three lines to the `postgresql.conf`:

```
archive_mode = yes
archive_command = '/usr/local/bin/wal-g wal-push %p'
archive_timeout = 60
```

However, how to manage creating/modifying the `postgresql.conf` in a persistent manner, that allows people to opt-in?
[This is the info on the Docker postgres image page itself about modifying the database config](https://github.com/docker-library/docs/blob/master/postgres/README.md#database-configuration).