### PR TITLE
add timescaledb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,15 @@ LABEL fly.pg-version=${PG_VERSION}
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     ca-certificates curl bash dnsutils vim-tiny procps jq haproxy \
+    && apt autoremove -y
+
+RUN echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(cat /etc/os-release | grep VERSION_CODENAME | cut -d'=' -f2) main" > /etc/apt/sources.list.d/timescaledb.list \
+    && curl -L https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
     postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
-    postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \    
+    postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+    timescaledb-2-postgresql-$PG_MAJOR \ 
     && apt autoremove -y
 
 COPY --from=stolon /go/src/app/bin/* /usr/local/bin/

--- a/pkg/flypg/config.go
+++ b/pkg/flypg/config.go
@@ -105,6 +105,7 @@ func InitConfig(filename string) (*Config, error) {
 			"max_parallel_workers":            "8",
 			"max_parallel_workers_per_gather": "2",
 			"wal_compression":                 "on",
+			"shared_preload_libraries":        "timescaledb",
 		},
 	}
 

--- a/pkg/flypg/config.go
+++ b/pkg/flypg/config.go
@@ -105,7 +105,6 @@ func InitConfig(filename string) (*Config, error) {
 			"max_parallel_workers":            "8",
 			"max_parallel_workers_per_gather": "2",
 			"wal_compression":                 "on",
-			"shared_preload_libraries":        "timescaledb",
 		},
 	}
 


### PR DESCRIPTION
This adds the `timescaledb` extension. Clusters _created_ with this branch can enable timescale by running:

```
CREATE EXTENSION IF NOT EXISTS timescaledb;
```

Existing clusters upgraded to this image will first need to run this:

```
> fly ssh console -a <db-name>

export $(cat /data/.env | xargs)
stolonctl update --patch '{"pgParameters": { "shared_preload_libraries": "timescaledb" } }'
```

Then restart each VM.

We have some decisions to make about how we ship this. We could create a `flyio/postgres:timescale` tag. Or we can just merge this into all the other releases.