### PR TITLE
Reliability improvements

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -157,8 +157,9 @@ func main() {
 	svisor.AddProcess("sentinel", stolonCmd("stolon-sentinel"), supervisor.WithEnv(sentinelEnv), supervisor.WithRestart(0, 3*time.Second))
 
 	proxyEnv := map[string]string{
-		"FLY_APP_NAME":   os.Getenv("FLY_APP_NAME"),
-		"PRIMARY_REGION": os.Getenv("PRIMARY_REGION"),
+		"FLY_APP_NAME":      os.Getenv("FLY_APP_NAME"),
+		"PRIMARY_REGION":    os.Getenv("PRIMARY_REGION"),
+		"PG_LISTEN_ADDRESS": node.PrivateIP.String(),
 	}
 	svisor.AddProcess("proxy", "/usr/sbin/haproxy -W -db -f /fly/haproxy.cfg", supervisor.WithEnv(proxyEnv), supervisor.WithRestart(0, 1*time.Second))
 

--- a/config/haproxy.cfg
+++ b/config/haproxy.cfg
@@ -35,3 +35,4 @@ backend bk_db
     http-check expect string leader
     http-check disable-on-404
     server-template pg 10 $PRIMARY_REGION.$FLY_APP_NAME.internal:5433 check port 5500 resolvers flydns resolve-prefer ipv6 init-addr none on-marked-down shutdown-sessions
+    server pg [$PG_LISTEN_ADDRESS]:5433 check backup port 5500 on-marked-down shutdown-sessions


### PR DESCRIPTION
This cuts a bunch of chatter out of the logs and sets the local IP as a haproxy backup. This should make single node postgres behave better if there are DNS issues (which seem to crop up after repeated crashes).