### PR TITLE
Provide stolonctl environment variables to shells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN useradd -ms /bin/bash stolon
 RUN mkdir -p /run/haproxy/
 COPY --from=flyutil /fly/bin/* /usr/local/bin/
 
+ENV ENV="/fly/set-stolon-environment.sh"
+
 EXPOSE 5432
 
 CMD ["start"]

--- a/scripts/set-stolon-environment.sh
+++ b/scripts/set-stolon-environment.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -f /data/.env ]; then
+  export $(cat /data/.env)
+fi


### PR DESCRIPTION
Fixes #13.  We want to set the environment variables stolonctl expects (STOLONCTL_...) on shells so users can fly ssh console in and run stolonctl to more easily administrate their cluster.

Those environment variables are written to a file at `/data/.env` by [`start`](https://github.com/fly-apps/postgres-ha/blob/7a3ab744d28f314f7f7f2225e571889c3a6d2f21/cmd/start/main.go#L41) after the defaults are set. 

Unfortunately, the shell that is created by hallpass appears to be hard coded to `/bin/sh`, is not a login shell nor controllable by `/etc/passwd`, so our best option is to bake in the [POSIX `ENV`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_05_03) variable that [dash (1)](https://manpages.debian.org/stretch/dash/dash.1.en.html#Invocation) conforms:

> If the environment variable ENV is set on entry to an interactive shell, [...] the shell next reads commands from the file named in ENV. Therefore, a user should place [...] commands that are executed for every interactive shell inside the ENV file. 

If instead hallpass was either (1) creating a login shell, or (2) allowed us to change the shell from `/bin/sh` to `/bin/bash`, then it would be a bit more idiomatic / cleaner because we could simply put arbitrary shell scripts into `/etc/profile.d`. Note that customizing `/bin/sh` to point to `bash` rather than `dash` (by using e.g. `debconf-set-selections`) is not sufficient; bash will run in POSIX compatibility mode and won't read `/etc/bash.bashrc` as you might expect. 