### PR TITLE
Exec Bash just after sourcing stolon env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN useradd -ms /bin/bash stolon
 RUN mkdir -p /run/haproxy/
 COPY --from=flyutil /fly/bin/* /usr/local/bin/
 
-ENV ENV="/fly/set-stolon-environment.sh"
+ENV ENV="/fly/shell-init"
 
 EXPOSE 5432
 

--- a/scripts/set-stolon-environment.sh
+++ b/scripts/set-stolon-environment.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-if [ -f /data/.env ]; then
-  export $(cat /data/.env)
-fi

--- a/scripts/shell-init
+++ b/scripts/shell-init
@@ -1,0 +1,11 @@
+#!/bin/dash
+# Dash sources this file according to POSIX envvar $ENV declared in Dockerfile
+# https://manpages.debian.org/stretch/dash/dash.1.en.html#Invocation
+
+if [ -f /data/.env ]; then
+  export $(cat /data/.env)
+fi
+
+# Upgrade to Bash shell
+unset ENV
+exec /bin/bash "$@"


### PR DESCRIPTION
Bash shell is so much better than Dash for interactive use

```
~$ fly ssh console -a dangra-pg-m8
Connecting to [fdaa:0:5ea6:a7b:1f60:e3f:8521:2]... complete
root@73d8ddd9c73089:/# echo $BASH_VERSION
5.1.4(1)-release
```