### PR TITLE
Isolate TimescaleDB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,42 +33,56 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            PG_VERSION=12.10
+            PG_VERSION=12.13
             VERSION=${{ steps.get-latest-tag.outputs.tag }}
           context: .
           file: ./Dockerfile
           push: true
           tags: |
             flyio/postgres:12
-            flyio/postgres:12.10
+            flyio/postgres:12.13
       -
         name: Build and push Postgres 13
         id: docker_build_13
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            PG_VERSION=13.6
+            PG_VERSION=13.9
             VERSION=${{ steps.get-latest-tag.outputs.tag }}
           context: .
           file: ./Dockerfile
           push: true
           tags: |
             flyio/postgres:13
-            flyio/postgres:13.6
+            flyio/postgres:13.9
       -
         name: Build and push Postgres 14
         id: docker_build_14
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            PG_VERSION=14.4
+            PG_VERSION=14.6
             VERSION=${{ steps.get-latest-tag.outputs.tag }}
           context: .
           file: ./Dockerfile
           push: true
           tags: |
             flyio/postgres:14
-            flyio/postgres:14.4
+            flyio/postgres:14.6
+      -
+        name: Build and push TimescaleDB 14
+        id: docker_build_ts_14
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            PG_VERSION=14.6
+            VERSION=${{ steps.get-latest-tag.outputs.tag }}
+          context: .
+          file: ./Dockerfile-timescaledb
+          push: true
+          tags: |
+            flyio/postgres-timescaledb:14
+            flyio/postgres-timescaledb:14.6
       -
         name: Postgres 12 Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile-timescaledb
+++ b/Dockerfile-timescaledb
@@ -1,0 +1,66 @@
+ARG PG_VERSION=14.6
+ARG VERSION=v0.0.33
+
+FROM golang:1.16 as flyutil
+ARG VERSION
+
+WORKDIR /go/src/github.com/fly-examples/postgres-ha
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/flyadmin ./cmd/flyadmin
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
+
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg-restart ./.flyctl/cmd/pg-restart
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg-role ./.flyctl/cmd/pg-role
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg-failover ./.flyctl/cmd/pg-failover
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/stolonctl-run ./.flyctl/cmd/stolonctl-run
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg-settings ./.flyctl/cmd/pg-settings
+
+COPY ./bin/* /fly/bin/
+
+FROM flyio/stolon:327008e as stolon
+
+FROM wrouesnel/postgres_exporter:latest AS postgres_exporter
+
+FROM postgres:${PG_VERSION}
+ARG VERSION 
+ARG POSTGIS_MAJOR=3
+ARG WALG_VERSION=2.0.0
+
+LABEL fly.app_role=postgres_cluster
+LABEL fly.version=${VERSION}
+LABEL fly.pg-version=${PG_VERSION}
+LABEL fly.flavor=timescaledb
+
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates curl bash dnsutils vim-tiny procps jq haproxy \
+    && apt autoremove -y
+
+RUN echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(cat /etc/os-release | grep VERSION_CODENAME | cut -d'=' -f2) main" > /etc/apt/sources.list.d/timescaledb.list \
+    && curl -L https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
+    postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+    timescaledb-2-postgresql-$PG_MAJOR \
+    timescaledb-toolkit-postgresql-$PG_MAJOR \
+    && apt autoremove -y \
+    && echo 'Installing wal-g' \
+    && curl -L https://github.com/wal-g/wal-g/releases/download/v${WALG_VERSION}/wal-g-pg-ubuntu-18.04-amd64 > /usr/local/bin/wal-g \
+    && chmod +x /usr/local/bin/wal-g
+
+COPY --from=stolon /go/src/app/bin/* /usr/local/bin/
+COPY --from=postgres_exporter /postgres_exporter /usr/local/bin/
+
+ADD /scripts/* /fly/
+ADD /config/* /fly/
+RUN useradd -ms /bin/bash stolon
+RUN mkdir -p /run/haproxy/
+COPY --from=flyutil /fly/bin/* /usr/local/bin/
+
+ENV ENV="/fly/shell-init"
+
+EXPOSE 5432
+
+CMD ["start"]

--- a/Dockerfile-timescaledb
+++ b/Dockerfile-timescaledb
@@ -60,6 +60,7 @@ RUN mkdir -p /run/haproxy/
 COPY --from=flyutil /fly/bin/* /usr/local/bin/
 
 ENV ENV="/fly/shell-init"
+ENV TIMESCALE_DB_ENABLED=true
 
 EXPOSE 5432
 

--- a/Dockerfile-timescaledb
+++ b/Dockerfile-timescaledb
@@ -1,5 +1,5 @@
 ARG PG_VERSION=14.6
-ARG VERSION=v0.0.33
+ARG VERSION=custom
 
 FROM golang:1.16 as flyutil
 ARG VERSION

--- a/Dockerfile-timescaledb
+++ b/Dockerfile-timescaledb
@@ -60,7 +60,7 @@ RUN mkdir -p /run/haproxy/
 COPY --from=flyutil /fly/bin/* /usr/local/bin/
 
 ENV ENV="/fly/shell-init"
-ENV TIMESCALE_DB_ENABLED=true
+ENV TIMESCALEDB_ENABLED=true
 
 EXPOSE 5432
 

--- a/pkg/flypg/config.go
+++ b/pkg/flypg/config.go
@@ -122,7 +122,7 @@ func InitConfig(filename string) (*Config, error) {
 	}
 
 	if len(preloadShared) > 0 {
-		cfg.PGParameters["shared-preload-libraries"] = strings.Join(preloadShared, ",")
+		cfg.PGParameters["shared_preload_libraries"] = strings.Join(preloadShared, ",")
 	}
 
 	if initMode == InitModeNew {

--- a/pkg/flypg/config.go
+++ b/pkg/flypg/config.go
@@ -41,7 +41,7 @@ func InitConfig(filename string) (*Config, error) {
 
 	// Detect if TimescaleDB is installed.
 	preloadShared := []string{}
-	tsEnabled, err := strconv.ParseBool(os.Getenv("TIMESCALE_DB_ENABLED"))
+	tsEnabled, err := strconv.ParseBool(os.Getenv("TIMESCALEDB_ENABLED"))
 	if err == nil && tsEnabled {
 		preloadShared = append(preloadShared, "timescaledb")
 	}


### PR DESCRIPTION
This works to move TimescaleDB into a separate image track: `flyio/postgres-timescaledb`.

Eventually users will need to migrate to this image in order to leverage timescale.  