### PR TITLE
Proxy local postgres so it can be exposed as a service for read only replicas

### DIFF
--- a/config/haproxy.cfg
+++ b/config/haproxy.cfg
@@ -36,3 +36,11 @@ backend bk_db
     http-check disable-on-404
     server-template pg 10 $PRIMARY_REGION.$FLY_APP_NAME.internal:5433 check port 5500 resolvers flydns resolve-prefer ipv6 init-addr none on-marked-down shutdown-sessions
     server pg [$PG_LISTEN_ADDRESS]:5433 check backup port 5500 on-marked-down shutdown-sessions
+
+# stolon binds postgres only on fdaa:* ipv6 address which is not reachable by fly-proxy
+# Wildcard binding won't interfere with $PG_LISTEN_ADDRESS binding
+listen local_postgresql
+    mode tcp
+    bind *:5433
+    bind :::5433
+    server pg [$PG_LISTEN_ADDRESS]:5433


### PR DESCRIPTION
Bindings look like:
<img width="956" alt="image" src="https://github.com/fly-apps/postgres-ha/assets/37369/45d0b1c1-5274-4fe8-8657-907eb201431c">
